### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ The steps to build the code into a package and run the example with it remain as
 We follow [Semantic Versioning 2.0](https://semver.org/).
 
 Steps:
-1. Update [CHANGELOG.md](./CHANGELOG.md) with the new version
+1. Update [CHANGELOG.md](./CHANGELOG.md) with the new version. Note, there might be existing version which is not published in the file, run a cross check with last released git tag to decide the actual version to be published.
 2. Update [pubspec.yaml](./pubspec.yaml) with the new version
 4. Commit and push the change
 5. Create release tag


### PR DESCRIPTION
In some case, there might be existing version which is not published in CHANGELOG.md, we should run a cross check to find out the actual version to be published. This change is to add the step in the publishing process.